### PR TITLE
feature/1: Added tournament type detection to avoid parsing unofficial events

### DIFF
--- a/usq_site_scraper/scraper.py
+++ b/usq_site_scraper/scraper.py
@@ -11,7 +11,11 @@ _CATCH_MARKERS = ['*', '^', '!']
 _LOG_ERROR_FILE = 'error_log.txt'
 _LOG_PROGRESS_FILE = 'log.txt'
 _EVENTS_LINK = "https://www.usquidditch.org/events/calendar/{}"
-
+_CALENDAR_COLORS = {'#0054A6':'Official Tournament',
+                    '#D1C221':'USQ Event',
+                    '#BA3434':'USQ Sanctioned Event',
+                    '#1B996A':'Unofficial Tournament',
+                    '#CB7005':'Other'}
 
 def clean_soup(soup_val):
     return soup_val.get_text().strip().replace(',', '').replace("'", "").replace('"', '')
@@ -68,18 +72,29 @@ def get_event_urls(start, end) -> list:
                 fetch_data(_EVENTS_LINK.format(slug)))
             if tournaments:
                 soup_month = BeautifulSoup(tournaments)
-                event_urls = [*event_urls,
-                              *['https://www.usquidditch.org' + v['href'] for v in soup_month.findAll('div', {'class': 'event'})]]
+                for v in soup_month.findAll('div',{'class':'event'}):
+                    official = True
+                    try:
+                        color = v.find('div',{'class':'calendar_box'})['style'].split(':')[-1].upper()
+                        if  color in _CALENDAR_COLORS and _CALENDAR_COLORS[color] in ['Unofficial Tournament', 'Other']:
+                            official = False
+                    except Exception as e:
+                        _log_exception(e, 'testing event for official status', str(v['href']))
+                    if official:
+                        event_urls.append('https://www.usquidditch.org' + v['href'])
+                    else:
+                        _log_progress('WARNING: Skipping tournament {} due to unofficial status'.format(v['href']))
             else:
                 _log_exception(Exception('No events in month'), 'obtaining event list from page', slug)
                 _log_progress('WARNING: No events in month {}'.format(slug))
         except Exception as e:
             _log_exception(e, 'obtaining event list from page', slug)
             _log_progress('FAILURE: Obtaining event list from page {}'.format(slug))
-        if month == 12:
-            month, year = 1, year + 1
-        else:
-            month, year = month + 1, year
+        finally:
+            if month == 12:
+                month, year = 1, year + 1
+            else:
+                month, year = month + 1, year
     return event_urls
 
 


### PR DESCRIPTION
**_CALENDAR_COLORS** is a dictionary which now contains (hard coded) a list of every hexcode color marking on the [USQ calendar page](https://www.usquidditch.org/events/calendar/201902) - marking a tournament as a USQ Event, USQ Sanctioned Event, Official Tournament, Unofficial Tournament, or Other. 

update only uses **_CALENDAR_COLORS** to check if a tournament is official (includes USQ + USQ Sanctioned Events as well), and does not parse unofficial events. 

If event type cannot be ascertained, it is assumed to be an official event. 
